### PR TITLE
fix(MarketClientProxy/MarketDiamond): MCP-01C remove payable constructors

### DIFF
--- a/contracts/market/client/MarketClientProxy.sol
+++ b/contracts/market/client/MarketClientProxy.sol
@@ -44,7 +44,7 @@ contract MarketClientProxy is IMarketClientProxy, SeenConstants, Proxy {
         address _accessController,
         address _marketController,
         address _impl
-    ) payable {
+    ) {
 
         // Get the ProxyStorage struct
         MarketClientLib.ProxyStorage storage ps = MarketClientLib.proxyStorage();

--- a/contracts/market/diamond/MarketDiamond.sol
+++ b/contracts/market/diamond/MarketDiamond.sol
@@ -37,7 +37,7 @@ contract MarketDiamond {
         IAccessControlUpgradeable _accessController,
         IDiamondCut.FacetCut[] memory _facetCuts,
         bytes4[] memory _interfaceIds
-    ) payable {
+    ) {
 
         // Get the DiamondStorage struct
         DiamondLib.DiamondStorage storage ds = DiamondLib.diamondStorage();


### PR DESCRIPTION
#27 

Awaiting further information in case it helps clarify why this was done in the reference implementation: https://github.com/mudgen/diamond-2-hardhat/issues/2